### PR TITLE
fix: date format when creating scheduled task

### DIFF
--- a/Always Active Hours.bat
+++ b/Always Active Hours.bat
@@ -284,7 +284,7 @@ set "dateStem=!dateStem: =!"
 set "dateCore=%DATE%"
 
 :: Split Date Core into Parts
-for /f "tokens=1-4" %%A in ("!dateCore!") do (
+for /f "tokens=1-4 delims=%delims%" %%A in ("!dateCore!") do (
 	if not "%%D"=="" (
 		:: Separate the weekday prefix if present
 		set "weekday=%%A"
@@ -357,11 +357,11 @@ if "!month:~0,1!"=="0" set "month=!month:~1!"
 if "%month%" LSS "0" set "invalidMonth=1"
 if "%month%" GEQ 13 set "invalidMonth=1"
 
-if "%month%" LSS 10 set "month=0%month%"
+if %month% LSS 10 set "month=0%month%"
 
 :: Decimal interpretation for days
 if "!day:~0,1!"=="0" set "day=!day:~1!"
-if "%day%" LSS 10 set "day=0%day%"
+if %day% LSS 10 set "day=0%day%"
 
 :: End the local block and return results in global variables
 endlocal & (


### PR DESCRIPTION
Only space was used to split the date retrieved from the system.
Looks like you left out the delims parameter in during the previous commit a1e20a342d845fd94c5be2c17705ed51312d8224.
I have added the delims parameter in line 287.

0 was always added to current month and day even if they were double-digit because they were compared as strings.
Quotation marks have been removed when comparing the numbers in line 360 and 364.

The new line break in line 1910 is unintentional.
I used the web editor, and it wasn't shown in the branch patch, but only appeared after the pull request was submitted.
I am not sure how to remove it (and keep it as no end-of-line) from my side.